### PR TITLE
fix: [#42] Let action add a description to the go.mod update PR

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -71,8 +71,9 @@ runs:
         echo "create pr..."
         gh pr create \
           --base main \
-          --head "${GOMOD_GO_VERSION_UPDATER_ACTION_BRANCH}" \
+          --body "${GOMOD_GO_VERSION_UPDATER_ACTION_MESSAGE}" \
           --fill \
+          --head "${GOMOD_GO_VERSION_UPDATER_ACTION_BRANCH}" \
           --label dependencies \
           --label go \
           --label ${GOMOD_GO_VERSION_UPDATER_LABEL}


### PR DESCRIPTION
This PR will ensure that this action will create a PR with a description if the go version in a go.mod file will be updated.