### PR TITLE
build: [#49] Dependabot could not update PIP packages due to missing …

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -5,12 +5,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.7
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5.0.0
         with:
           python-version: 3.9.18
-      - name: Install dependencies
+          cache: 'pip'
+      - name: Install PIP packages defined in requirements.txt
         run: |
-          pip install pytest pytest-cov requests
+          pip install -r requirements.txt
       - name: Run tests
         run: |
           pytest --cov=main test.py --verbose --capture=no --cov-report term-missing

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+coverage==7.4.0
+pytest-cov==4.0.0
+requests==2.27.0


### PR DESCRIPTION
Once merged, Dependabot can start creating PRs as it requires such to determine what should be updated.