### PR TITLE
fix: [#88] Quote all labels that have spaces. Otherwise a PR to update the go version cannot be created

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,17 +53,17 @@ runs:
           fi
         }
         if ! check_label_exists ${DEPENDENCIES_LABEL}; then
-          gh label create ${DEPENDENCIES_LABEL} \
+          gh label create "${DEPENDENCIES_LABEL}" \
             --color "#0366d6" \
             --description "Pull requests that update a dependency file"
         fi
         if ! check_label_exists ${GO_LABEL}; then
-          gh label create ${GO_LABEL} \
+          gh label create "${GO_LABEL}" \
             --color "#16e2e2" \
             --description "Pull requests that update Go code"
         fi
         if ! check_label_exists ${GOMOD_GO_VERSION_UPDATER_LABEL}; then
-          gh label create ${GOMOD_GO_VERSION_UPDATER_LABEL} \
+          gh label create "${GOMOD_GO_VERSION_UPDATER_LABEL}" \
             --color "#F50BAB" \
             --description "Pull requests that update Go version in the go.mod file"
         fi
@@ -120,19 +120,35 @@ runs:
           exit 0
         fi
 
+        # echo "before: ${{ inputs.extra-pr-label }}"
+        # if [ -n "${{ inputs.extra-pr-label }}" ]; then
+        #   export GOMOD_GO_VERSION_UPDATER_LABEL_EXTRA="--label '${{ inputs.extra-pr-label }}'"
+        # fi
+        # echo "after: ${GOMOD_GO_VERSION_UPDATER_LABEL_EXTRA}"
+
+        labels=("${DEPENDENCIES_LABEL}" "${GO_LABEL}" "${GOMOD_GO_VERSION_UPDATER_LABEL}")
+
         if [ -n "${{ inputs.extra-pr-label }}" ]; then
-          export GOMOD_GO_VERSION_UPDATER_LABEL_EXTRA="--label ${{ inputs.extra-pr-label }}"
+          labels+=("${{ inputs.extra-pr-label }}")
         fi
 
+        echo "Labels:"
+        for label in "${labels[@]}"; do
+          echo "'$label'"
+        done
+
         echo "creating pr..."
+        label_args=()
+        for label in "${labels[@]}"; do
+          label_args+=(--label "$label")
+        done
+
         gh pr create \
           --base main \
           --body "${GOMOD_GO_VERSION_UPDATER_ACTION_MESSAGE}" \
           --fill \
           --head "${GOMOD_GO_VERSION_UPDATER_ACTION_BRANCH}" \
-          --label ${DEPENDENCIES_LABEL} \
-          --label ${GO_LABEL} \
-          --label ${GOMOD_GO_VERSION_UPDATER_LABEL} ${GOMOD_GO_VERSION_UPDATER_LABEL_EXTRA}
+          "${label_args[@]}"
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This pull request includes changes to the `action.yml` file to improve the handling of labels in shell commands by adding quotes around variable references. This ensures that the labels are correctly interpreted, even if they contain spaces or special characters.

Changes to label handling:

* Quoted the `${DEPENDENCIES_LABEL}`, `${GO_LABEL}`, and `${GOMOD_GO_VERSION_UPDATER_LABEL}` variables in the `gh label create` commands to ensure proper handling of label names.
* Quoted the `${{ inputs.extra-pr-label }}` variable in the `export` command to handle extra PR labels correctly.
* Quoted the `${DEPENDENCIES_LABEL}`, `${GO_LABEL}`, and `${GOMOD_GO_VERSION_UPDATER_LABEL}` variables in the `gh pr create` command to ensure labels are applied correctly.