### PR TITLE
build: Dependabot group updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,19 @@
 ---
 version: 2
 updates:
-  - package-ecosystem: 'github-actions'
-    directory: '/'
-    reviewers:
-      - '030'
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: 'daily'
-  - package-ecosystem: 'pip'
-    directory: '/'
-    reviewers:
-      - '030'
+      interval: "weekly"
+    groups:
+      github-actions-all:
+        patterns:
+          - "*"
+  - package-ecosystem: "pip"
+    directory: "/"
     schedule:
-      interval: 'daily'
+      interval: "weekly"
+    groups:
+      pip-all:
+        patterns:
+          - "*"


### PR DESCRIPTION
Prevent PR overloading by ensuring that Dependabot updates occur weekly.