### PR TITLE
fix: Multiple quick, small fixes, i.e. check whether update branch exists and omit install pytest when running action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,13 @@ runs:
     - name: update go version and push branch
       run: |
         git fetch -p -P
-        git checkout -b ${GOMOD_GO_VERSION_UPDATER_ACTION_BRANCH}
+
+        if (git ls-remote --exit-code --heads origin refs/heads/${GOMOD_GO_VERSION_UPDATER_ACTION_BRANCH}); then
+          echo "Branch '${GOMOD_GO_VERSION_UPDATER_ACTION_BRANCH}' already exists."
+          git checkout ${GOMOD_GO_VERSION_UPDATER_ACTION_BRANCH}
+        else
+          git checkout -b ${GOMOD_GO_VERSION_UPDATER_ACTION_BRANCH}
+        fi
 
         python --version
         python3 --version

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ runs:
         python-version: 3.9.18
     - name: Install dependencies
       run: |
-        pip install pytest pytest-cov requests
+        pip install requests
       shell: bash
     - name: Create labels
       run: |

--- a/action.yml
+++ b/action.yml
@@ -87,7 +87,8 @@ runs:
 
         export GOMOD_GO_VERSION_UPDATER_ACTION_NEW_GOLANG_VERSION_OUTPUT=$(echo ${GOMOD_GO_VERSION_UPDATER_ACTION_OUTPUT} |\
           grep "bump golang version" |\
-          sed "s|.*\(bump.*\)|\1|")
+          sed "s|.*\(bump.*\)|\1|" |\
+          head -n 1)
         echo "GOMOD_GO_VERSION_UPDATER_ACTION_NEW_GOLANG_VERSION_OUTPUT: ${GOMOD_GO_VERSION_UPDATER_ACTION_NEW_GOLANG_VERSION_OUTPUT}"
 
         export GOMOD_GO_VERSION_UPDATER_ACTION_MESSAGE="build(deps): ${GOMOD_GO_VERSION_UPDATER_ACTION_NEW_GOLANG_VERSION_OUTPUT}"

--- a/main.py
+++ b/main.py
@@ -1,9 +1,10 @@
 import logging
 import os
 import re
-import requests
 import sys
 from typing import Tuple
+
+import requests
 
 DOCKERFILE = "Dockerfile"
 GO_MOD_FILE = "go.mod"
@@ -100,6 +101,7 @@ def update_dockerfile_version(
                 else f"{new_major}.{new_minor}"
             )
             updated_lines.append(line.replace(version, new_version))
+            logging.info(f"bump golang version from {version} to {new_version}")
         else:
             updated_lines.append(line)
 


### PR DESCRIPTION
- No longer install `pytest` when running the action. We do not need it and installing it only slows us down.
- Add logging when updating Dockerfiles. This makes sure we also have a commit message when only updating Dockerfiles.
- Check if there is already a branch created by the updater and if so reuse that one.