### PR TITLE
feat: Add support for nested go.mod files

### DIFF
--- a/main.py
+++ b/main.py
@@ -36,10 +36,6 @@ def get_latest_go_version():
 
 
 def get_go_version_from_mod_file(go_mod_file: str) -> Tuple[str, bool]:
-    if not os.path.exists(go_mod_file):
-        logging.error(f"The file '{go_mod_file}' does not exist.")
-        return "", False
-
     with open(go_mod_file, "r") as file:
         content = file.read()
         match = re.search(r"go\s(\d+)\.(\d+)\.?(\d+)?", content)

--- a/main.py
+++ b/main.py
@@ -14,16 +14,16 @@ LOGGING_LEVEL = os.getenv(
 )
 
 
-def get_go_version_from_mod_file() -> Tuple[str, bool]:
-    if not os.path.exists(GO_MOD_FILE):
-        logging.error(f"The file '{GO_MOD_FILE}' does not exist.")
+def get_go_version_from_mod_file(go_mod_file: str) -> Tuple[str, bool]:
+    if not os.path.exists(go_mod_file):
+        logging.error(f"The file '{go_mod_file}' does not exist.")
         return "", False
 
-    with open(GO_MOD_FILE, "r") as file:
+    with open(go_mod_file, "r") as file:
         content = file.read()
         match = re.search(r"go\s(\d+)\.(\d+)\.?(\d+)?", content)
         if not match:
-            raise ValueError(f"No Go version defined in file: {GO_MOD_FILE}")
+            raise ValueError(f"No Go version defined in file: {go_mod_file}")
         major, minor, patch = match.groups()
         version = f"{major}.{minor}" + (f".{patch}" if patch else "")
         return version, bool(patch)
@@ -118,7 +118,7 @@ def main():
         latest_major, latest_minor, latest_patch
     )
 
-    current_version, has_patch = get_go_version_from_mod_file()
+    current_version, has_patch = get_go_version_from_mod_file(GO_MOD_FILE)
     latest_major_minor = f"{latest_major}.{latest_minor}"
     if has_patch:
         update_go_version_in_mod_file(

--- a/main.py
+++ b/main.py
@@ -49,18 +49,20 @@ def get_go_version_from_mod_file(go_mod_file: str) -> Tuple[str, bool]:
         return version, bool(patch)
 
 
-def update_go_version_in_mod_file(current_version: str, new_version: str):
+def update_go_version_in_mod_file(
+    go_mod_file: str, current_version: str, new_version: str
+):
     try:
-        with open(GO_MOD_FILE, "r") as file:
+        with open(go_mod_file, "r") as file:
             content = file.read()
         content = re.sub(GO_MOD_GO_VERSION_REGEX, f"go {new_version}", content)
-        with open(GO_MOD_FILE, "w") as file:
+        with open(go_mod_file, "w") as file:
             file.write(content)
         logging.info(
             f"bump golang version from {current_version} to {new_version}"
         )
     except FileNotFoundError:
-        logging.info(f"File not found: {GO_MOD_FILE}")
+        logging.info(f"File not found: {go_mod_file}")
 
 
 def update_dockerfile_version_in_directory(
@@ -122,11 +124,14 @@ def main():
     latest_major_minor = f"{latest_major}.{latest_minor}"
     if has_patch:
         update_go_version_in_mod_file(
+            GO_MOD_FILE,
             current_version,
             f"{latest_major_minor}.{latest_patch}",
         )
         return
-    update_go_version_in_mod_file(current_version, f"{latest_major_minor}")
+    update_go_version_in_mod_file(
+        GO_MOD_FILE, current_version, f"{latest_major_minor}"
+    )
 
 
 if __name__ == "__main__":

--- a/test.py
+++ b/test.py
@@ -14,6 +14,7 @@ from main import (
     get_go_version_from_mod_file,
     get_latest_go_version,
     main,
+    update_go_version_in_mod_file,
 )
 
 GO_VERSIONS_URL = "https://mocked-url.com"
@@ -174,6 +175,37 @@ class TestGetGoVersionFromModFile(unittest.TestCase):
         self.assertRaises(
             ValueError, get_go_version_from_mod_file, mod_file.name
         )
+
+
+class TestUpdateGoVersionInModFile(unittest.TestCase):
+    def test_update_go_version_in_mod_file_with_patch(self):
+        # Prepare go.mod file
+        mod_file = tempfile.NamedTemporaryFile(delete_on_close=False)
+        mod_file.write(b"module example\n\ngo 1.2.3\n")
+        mod_file.close()
+
+        update_go_version_in_mod_file(mod_file.name, "1.2.3", "1.2.4")
+
+        with open(mod_file.name, "r") as file:
+            content = file.read()
+            self.assertIn("go 1.2.4", content)
+
+    def test_update_go_version_in_mod_file_without_patch(self):
+        # Prepare go.mod file
+        mod_file = tempfile.NamedTemporaryFile(delete_on_close=False)
+        mod_file.write(b"module example\n\ngo 1.2\n")
+        mod_file.close()
+
+        update_go_version_in_mod_file(mod_file.name, "1.2", "1.4")
+
+        with open(mod_file.name, "r") as file:
+            content = file.read()
+            self.assertIn("go 1.4", content)
+
+    def test_update_go_version_in_mod_file_missing_file(self):
+        with patch("logging.info") as mock_logging:
+            update_go_version_in_mod_file("nonexistent_file", "1.2", "1.4")
+            mock_logging.assert_called_with("File not found: nonexistent_file")
 
 
 if __name__ == "__main__":

--- a/test.py
+++ b/test.py
@@ -161,12 +161,10 @@ class TestGetGoVersionFromModFile(unittest.TestCase):
         result = get_go_version_from_mod_file(mod_file.name)
         self.assertEqual(result, ("1.2", False))
 
-    # FIXME: I do not agree with the current choice to ignore the non existing
-    # file, but I'll get to that in a later commit. ;-)
-    # def test_get_go_version_missing_file(self):
-    #     self.assertRaises(
-    #         FileNotFoundError, get_go_version_from_mod_file, "nonexistent_file"
-    #     )
+    def test_get_go_version_missing_file(self):
+        self.assertRaises(
+            FileNotFoundError, get_go_version_from_mod_file, "nonexistent_file"
+        )
 
     def test_invalid_file_content(self):
         # Prepare go.mod file


### PR DESCRIPTION
This closes issue #95.

I know that performance wise this solution is not optimal: we open and read the `go.mod` files twice (once to fetch the current version and once to update it). However, this implementation stays close to the original code and by splitting the version fetching and updating functionality, these are easier to test separately. And assuming the number of `go.mod` files per repo will be limited anyway, I do not expect this to be the bottleneck.

This PR is probably best reviewed by going commit by commit.