### PR TITLE
feat: Ignore .venv directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .coverage
+.venv
 .vscode
 __pycache__


### PR DESCRIPTION
Using the `.venv` directory for virtual environments is pretty standard so let's ignore that one in Git.