### PR TITLE
fix: [#95] Run `go mod tidy` in all directories with `go.mod` files

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -153,7 +153,7 @@ runs:
         GH_TOKEN: ${{ github.token }}
     - uses: actions/setup-go@v5.3.0
       with:
-        go-version-file: "go.mod"
+        go-version: 'stable'
         cache: false
     - run: |
         git config --global url.https://${{ inputs.github-token-for-downloading-private-go-modules }}@github.com/.insteadOf https://github.com/

--- a/action.yml
+++ b/action.yml
@@ -161,7 +161,13 @@ runs:
       if: ${{ inputs.github-token-for-downloading-private-go-modules != '' }}
     - name: go mod tidy
       run: |
-        go mod tidy
+        CURRENT_DIR=$(pwd)
+        for DIR in $(find . -name "go.mod" -exec dirname {} +); do
+          cd $DIR
+          echo "Running 'go mod tidy' in $DIR"
+          go mod tidy
+          cd $CURRENT_DIR
+        done
       shell: bash
     - name: commit and force push if needed
       run: |


### PR DESCRIPTION
In previous changes to fix #95 we no longer assume that there is only one `go.mod` file. And also that that file might not be located in the root of the project.

This change also takes that into account for the part where we want to run `go mod tidy` in our action.