### PR TITLE
fix: pin nested actions to full-length commit SHAs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ runs:
     - name: display the gh cli version
       run: gh --version
       shell: bash
-    - uses: actions/checkout@v4.2.2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         ref: main
         fetch-depth: 0
@@ -28,7 +28,7 @@ runs:
         echo "GOMOD_GO_VERSION_UPDATER_LABEL=gomod-go-version-updater" >> $GITHUB_ENV
         echo "GOMOD_GO_VERSION_UPDATER_ACTION_BRANCH=update-go-version-in-go-mod-file" >> $GITHUB_ENV
       shell: bash
-    - uses: actions/setup-python@v5.6.0
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: 3.9.18
     - name: Install dependencies
@@ -152,7 +152,7 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
-    - uses: actions/setup-go@v5.5.0
+    - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version: 'stable'
         cache: false


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><div style="box-sizing: border-box; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="edit-comment-hide" style="box-sizing: border-box;"><task-lists disabled="" sortable="" style="box-sizing: border-box;"><div class="comment-body markdown-body js-comment-body soft-wrap user-select-contain d-block" style="box-sizing: border-box; display: block !important; font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; overflow-wrap: break-word; font-size: 14px; line-height: 1.5; width: 814px; padding: 16px; color: rgb(240, 246, 252); overflow: visible;"><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px;"><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">action.yml</code><span> </span>calls three actions pinned to version tags:</p><div class="highlight highlight-source-yaml notranslate position-relative overflow-auto" dir="auto" style="box-sizing: border-box; overflow: visible !important; position: relative !important; margin-bottom: 16px; background-color: rgba(0, 0, 0, 0);"><pre class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; margin-top: 0px; margin-bottom: 0px; tab-size: 4; overflow-wrap: normal; padding: 16px; color: rgb(240, 246, 252); background-color: rgb(21, 27, 35); border-radius: 6px; line-height: 1.45; overflow: auto; word-break: normal; min-height: 52px;">- <span class="pl-ent" style="box-sizing: border-box; color: rgb(126, 231, 135);">uses</span>: <span class="pl-s" style="box-sizing: border-box; color: rgb(165, 214, 255);">actions/checkout@v4.2.2</span>
- <span class="pl-ent" style="box-sizing: border-box; color: rgb(126, 231, 135);">uses</span>: <span class="pl-s" style="box-sizing: border-box; color: rgb(165, 214, 255);">actions/setup-python@v5.6.0</span>
- <span class="pl-ent" style="box-sizing: border-box; color: rgb(126, 231, 135);">uses</span>: <span class="pl-s" style="box-sizing: border-box; color: rgb(165, 214, 255);">actions/setup-go@v5.5.0</span></pre><div class="zeroclipboard-container position-absolute right-0 top-0" style="box-sizing: border-box; position: absolute !important; top: 0px !important; right: 0px !important;"><clipboard-copy aria-label="Copy code to clipboard" class="ClipboardButton btn js-clipboard-copy m-2 p-0" data-copy-feedback="Copied!" data-tooltip-direction="w" value="- uses: actions/checkout@v4.2.2
- uses: actions/setup-python@v5.6.0
- uses: actions/setup-go@v5.5.0" tabindex="0" role="button" style="box-sizing: border-box; margin: 8px !important; padding: 0px !important; font-size: 14px; font-weight: 500; white-space: nowrap; vertical-align: middle; cursor: pointer; user-select: none; appearance: none; border: 1px solid rgb(61, 68, 77); border-radius: 6px; line-height: 20px; display: inline-block; position: relative; color: rgb(240, 246, 252); background-color: rgb(33, 40, 48); box-shadow: none; transition: color 80ms cubic-bezier(0.33, 1, 0.68, 1), background-color 80ms cubic-bezier(0.33, 1, 0.68, 1), box-shadow 80ms cubic-bezier(0.33, 1, 0.68, 1), border-color 80ms cubic-bezier(0.33, 1, 0.68, 1);"><svg aria-hidden="true" data-component="Octicon" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-copy js-clipboard-copy-icon m-2 tmp-m-2"></svg></clipboard-copy></div></div><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px;">GitHub resolves nested<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">uses:</code><span> </span><strong style="box-sizing: border-box; font-weight: 600;">transitively when the consumer's job is set<br style="box-sizing: border-box;">up</strong>, before any<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">if:</code><span> </span>is evaluated. So in any repository whose ruleset enables<br style="box-sizing: border-box;"><em style="box-sizing: border-box;">"require actions to be pinned to a full-length commit SHA"</em>, this action cannot<br style="box-sizing: border-box;">be used at all. The job fails at setup in ~10s with no step logs<br style="box-sizing: border-box;">(<code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">startup_failure</code>):</p><blockquote style="box-sizing: border-box; margin: 0px 0px 16px; color: rgb(145, 152, 161); border-left: 3px solid rgb(61, 68, 77); padding: 0px 1em;"><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0px;">The actions<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">actions/checkout@v4.2.2</code>,<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">actions/setup-python@v5.6.0</code>, and<br style="box-sizing: border-box;"><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">actions/setup-go@v5.5.0</code><span> </span>are not allowed in<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">schubergphilis/item</code><span> </span>because all<br style="box-sizing: border-box;">actions must be from a repository owned by schubergphilis, created by GitHub,<br style="box-sizing: border-box;">or match one of the patterns:<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">actions/checkout@*</code>,<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">actions/setup-go@*</code>,<br style="box-sizing: border-box;"><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">actions/setup-python@*</code>, …<span> </span><strong style="box-sizing: border-box; font-weight: 600;">All actions must also be pinned to a<br style="box-sizing: border-box;">full-length commit SHA.</strong></p></blockquote><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px;">Note the last sentence: adding<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">actions/checkout@*</code><span> </span>to the allowlist patterns<br style="box-sizing: border-box;">does not help, because SHA pinning is an independent condition. The consumer's<br style="box-sizing: border-box;">own workflow is already fully SHA-pinned — only these nested references break it.</p><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px;">Observed in<span> </span><a href="https://github.com/schubergphilis/item" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(68, 147, 248); text-decoration: underline; text-underline-offset: 0.2rem;"><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">schubergphilis/item</code></a>,<br style="box-sizing: border-box;">where the scheduled<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">gomod-go-version-updater-action</code><span> </span>workflow has been failing<br style="box-sizing: border-box;">every day (e.g. run<br style="box-sizing: border-box;"><a href="https://github.com/schubergphilis/item/actions/runs/31156165374" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(68, 147, 248); text-decoration: underline; text-underline-offset: 0.2rem;">31156165374</a>).</p><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; border-bottom: 1px solid rgba(61, 68, 77, 0.7); padding-bottom: 0.3em;">Change</h2><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px;">Pin each of the three to the commit its tag already points at — no version<br style="box-sizing: border-box;">change, no behaviour change:</p><markdown-accessiblity-table data-catalyst="" style="box-sizing: border-box; display: block;">
Action | Tag | Commit
-- | -- | --
actions/checkout | v4.2.2 | 11bd71901bbe5b1630ceea73d27597364c9af683
actions/setup-python | v5.6.0 | a26af69be951a213d495a4c3e4e4022e16d87065
actions/setup-go | v5.5.0 | d35c59abb061a4a6fb18e82ac0862c26744d6ab5

</markdown-accessiblity-table><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px;">The version stays in a trailing<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;"># vX.Y.Z</code><span> </span>comment, which is the form Dependabot<br style="box-sizing: border-box;">reads and updates — so the existing<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">.github/dependabot.yml</code><span> </span>keeps bumping them.</p><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; border-bottom: 1px solid rgba(61, 68, 77, 0.7); padding-bottom: 0.3em;">Notes</h2><ul dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0px !important; padding: 0px; position: relative;"><li style="box-sizing: border-box; margin-left: 24px;">Consumers pin this action by tag/SHA, so a new release is needed before the<br style="box-sizing: border-box;">fix reaches them.</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;">This repo's own workflows (<code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">.github/workflows/python.yml</code>,<br style="box-sizing: border-box;"><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">mcvs-pr-validation.yml</code>) also use tag-pinned actions. Left alone here to keep<br style="box-sizing: border-box;">the change minimal — happy to include them if you'd prefer consistency.</li></ul></div></task-lists></div></div><form class="js-comment-update" id="issue-5088091239-edit-form" data-type="json" data-turbo="false" action="https://github.com/schubergphilis/gomod-go-version-updater-action/issues/3" accept-charset="UTF-8" method="post" style="box-sizing: border-box; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"></form><div class="pr-review-reactions " style="box-sizing: border-box; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div data-view-component="true" class="comment-reactions just-bottom js-reactions-container js-reaction-buttons-container social-reactions reactions-container d-flex" style="box-sizing: border-box; display: none; margin-bottom: 16px; margin-left: 16px;"><reactions-menu tabindex="-1" data-catalyst="" style="box-sizing: border-box; display: block;"><details data-action="toggle:reactions-menu#focusFirstItem" data-target="reactions-menu.details" class="dropdown details-reset details-overlay d-inline-block new-reactions-dropdown js-reaction-popover-container js-comment-header-reaction-button" style="box-sizing: border-box; display: inline-block !important; position: relative;"><summary data-target="reactions-menu.summary" aria-label="Add or remove reactions" aria-haspopup="true" data-view-component="true" class="circle reaction-dropdown-button reaction-dropdown-button--inline btn-invisible btn p-0 tmp-p-0 mr-1 tmp-mr-1 d-flex flex-justify-center flex-items-center color-bg-subtle border color-border-muted" style="box-sizing: border-box; display: flex !important; cursor: pointer; margin-right: 4px !important; padding: 0px !important; font-size: 14px; font-weight: 500; white-space: nowrap; vertical-align: middle; user-select: none; appearance: none; border: 1px solid rgba(61, 68, 77, 0.7) !important; border-radius: 9999.01px !important; line-height: 20px; position: relative; color: rgb(145, 152, 161); background-color: rgb(21, 27, 35) !important; box-shadow: none; transition: color 80ms cubic-bezier(0.33, 1, 0.68, 1), background-color 80ms cubic-bezier(0.33, 1, 0.68, 1), box-shadow 80ms cubic-bezier(0.33, 1, 0.68, 1), border-color 80ms cubic-bezier(0.33, 1, 0.68, 1); justify-content: center !important; align-items: center !important; width: 26px; height: 26px; list-style: none;"><svg height="18" aria-hidden="true" data-component="Octicon" viewBox="0 0 16 16" version="1.1" width="18" data-view-component="true" class="octicon octicon-smiley social-button-emoji"></svg></summary></details></reactions-menu></div></div><br class="Apple-interchange-newline"><!--EndFragment-->
</body>
</html>action.yml calls three actions pinned to version tags:

- uses: actions/checkout@v4.2.2
- uses: actions/setup-python@v5.6.0
- uses: actions/setup-go@v5.5.0
GitHub resolves nested uses: transitively when the consumer's job is set
up, before any if: is evaluated. So in any repository whose ruleset enables
"require actions to be pinned to a full-length commit SHA", this action cannot
be used at all. The job fails at setup in ~10s with no step logs
(startup_failure):

The actions actions/checkout@v4.2.2, actions/setup-python@v5.6.0, and
actions/setup-go@v5.5.0 are not allowed in schubergphilis/item because all
actions must be from a repository owned by schubergphilis, created by GitHub,
or match one of the patterns: actions/checkout@*, actions/setup-go@*,
actions/setup-python@*, … All actions must also be pinned to a
full-length commit SHA.

Note the last sentence: adding actions/checkout@* to the allowlist patterns
does not help, because SHA pinning is an independent condition. The consumer's
own workflow is already fully SHA-pinned — only these nested references break it.

Observed in [schubergphilis/item](https://github.com/schubergphilis/item),
where the scheduled gomod-go-version-updater-action workflow has been failing
every day (e.g. run
[31156165374](https://github.com/schubergphilis/item/actions/runs/31156165374)).

Change
Pin each of the three to the commit its tag already points at — no version
change, no behaviour change:

Action	Tag	Commit
actions/checkout	v4.2.2	11bd71901bbe5b1630ceea73d27597364c9af683
actions/setup-python	v5.6.0	a26af69be951a213d495a4c3e4e4022e16d87065
actions/setup-go	v5.5.0	d35c59abb061a4a6fb18e82ac0862c26744d6ab5
The version stays in a trailing # vX.Y.Z comment, which is the form Dependabot
reads and updates — so the existing .github/dependabot.yml keeps bumping them.

Notes
Consumers pin this action by tag/SHA, so a new release is needed before the
fix reaches them.
This repo's own workflows (.github/workflows/python.yml,
mcvs-pr-validation.yml) also use tag-pinned actions. Left alone here to keep
the change minimal — happy to include them if you'd prefer consistency.