### PR TITLE
fix: pin nested actions to full-length commit SHAs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ runs:
     - name: display the gh cli version
       run: gh --version
       shell: bash
-    - uses: actions/checkout@v5.0.0
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         ref: main
         fetch-depth: 0
@@ -28,7 +28,7 @@ runs:
         echo "GOMOD_GO_VERSION_UPDATER_LABEL=gomod-go-version-updater" >> $GITHUB_ENV
         echo "GOMOD_GO_VERSION_UPDATER_ACTION_BRANCH=update-go-version-in-go-mod-file" >> $GITHUB_ENV
       shell: bash
-    - uses: actions/setup-python@v6.0.0
+    - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
       with:
         python-version: 3.9.18
     - name: Install dependencies
@@ -152,7 +152,7 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
-    - uses: actions/setup-go@v6.0.0
+    - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
       with:
         go-version: 'stable'
         cache: false


### PR DESCRIPTION
## Problem

`action.yml` calls three actions pinned to version tags:

```yaml
- uses: actions/checkout@v5.0.0
- uses: actions/setup-python@v6.0.0
- uses: actions/setup-go@v6.0.0
```

GitHub resolves nested `uses:` **transitively when the consumer's job is set
up**, before any `if:` is evaluated. So in any repository whose ruleset enables
*"require actions to be pinned to a full-length commit SHA"*, this action cannot
be used at all. The consumer's job fails at setup in ~10s with no step logs
(`startup_failure`):

> The actions `actions/checkout@…`, `actions/setup-python@…`, and
> `actions/setup-go@…` are not allowed in `<org>/<repo>` because all actions must
> be from a repository owned by `<org>`, created by GitHub, or match one of the
> patterns: `actions/checkout@*`, `actions/setup-go@*`, `actions/setup-python@*`,
> … **All actions must also be pinned to a full-length commit SHA.**

Note the last sentence: adding `actions/checkout@*` and friends to the allowlist
patterns does **not** help, because SHA pinning is an independent condition. The
consumer's own workflow being fully SHA-pinned doesn't help either — only these
nested references break it, and a consumer cannot override them.

This is also what zizmor's `unpinned-uses` audit reports, and
`.github/workflows/zizmor.yml` was just added here at `minimum-severity: low`
with its own steps correctly SHA-pinned — so this change brings `action.yml` in
line with the standard this repo now applies to its own workflows.

## Change

Pin each of the three to the commit its tag already points at. **No version
changes** — `checkout` stays on v5.0.0, `setup-python` and `setup-go` on v6.0.0:

| Action | Version | Commit |
|---|---|---|
| `actions/checkout` | v5.0.0 | `08c6903cd8c0fde910a37f88322edcfb5dd907a8` |
| `actions/setup-python` | v6.0.0 | `e797f83bcb11b83ae66e0230d6156d7c80228e7c` |
| `actions/setup-go` | v6.0.0 | `44694675825211faa026b3c33043df3e48a5fa00` |

Each version stays in a trailing `# vX.Y.Z` comment, which is the form
Dependabot reads and updates — so the existing `.github/dependabot.yml` keeps
bumping them exactly as it does today.

## Notes

- Three lines changed, nothing else. No behaviour change.
- Supersedes #146, which was opened from a fork's `main` and had drifted to
  older action versions, so it conflicted. This branch is cut from current
  `main` and keeps your versions.
- Consumers pin this action by tag, so a release would be needed before the fix
  reaches them.
