### PR TITLE
fix: package main.py so the console script can import it

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,14 @@ dev = [
   "validate-pyproject==0.25",
 ]
 
+[tool.setuptools]
+# Declared explicitly to opt out of setuptools' flat-layout auto-discovery.
+# Auto-discovery runs `_analyse_flat_packages() or _analyse_flat_modules()`, and
+# the PEP 420 package finder picks up `assets/` as a namespace package. That
+# short-circuits the module finder, so `main.py` was omitted from the wheel and
+# the `gomod-go-version-updater` script failed with `No module named 'main'`.
+py-modules = ["main"]
+
 [tool.setuptools-git-versioning]
 enabled = true
 


### PR DESCRIPTION
## Problem

`gomod-go-version-updater` crashes on startup as soon as it is installed from a
wheel:

```
Traceback (most recent call last):
  File ".../bin/gomod-go-version-updater", line 3, in <module>
    from main import main
ModuleNotFoundError: No module named 'main'
```

Because the action captures the output with
`export VAR=$(gomod-go-version-updater 2>&1)`, `export`'s exit status masks the
command's, so `set -e -o pipefail` never trips. The traceback is swallowed into
the variable, the `grep "bump golang version"` yields nothing, `go.mod` is never
touched, and the step ends on `No changes to commit.` — the job stays **green
while doing nothing**.

Observed in a consumer repo on every scheduled run since `v0.3.6`.

## Root cause

`pyproject.toml` declares the entry point `gomod-go-version-updater = "main:main"`
but never declares `py-modules`, so it relies on setuptools flat-layout
auto-discovery. In `setuptools/discovery.py`:

```python
def _analyse_flat_layout(self) -> bool:
    return self._analyse_flat_packages() or self._analyse_flat_modules()   # short-circuits
```

`FlatLayoutPackageFinder` is PEP 420-based (no `__init__.py` required) and
`assets` is **not** in its exclude list. So once `assets/logos/*.png` was added,
discovery found `assets` + `assets.logos`, returned `True`, and
`_analyse_flat_modules()` was never reached. `py_modules` ends up empty and
`main.py` is left out of the wheel — while the console script that imports it is
still generated.

It fails silently because `_ensure_no_accidental_inclusion` only raises when
`len(detected) > 1`, and `assets.logos` is stripped as nested, leaving exactly
one top-level name.

Evidence:

- The built wheel is **4,464 bytes**, while `main.py` alone is 4,594 B and the
  PNG is 459 KB — the wheel is metadata only, containing neither.
- The last release without an `assets/` directory installs and runs fine;
  `main.py` is byte-identical between the two, and the only packaging-relevant
  change is the added `assets/`.

## Fix

Declare `py-modules` explicitly. This sets `dist.py_modules`, so
`_analyse_package_layout` returns early and auto-discovery is skipped entirely:
`main.py` is packaged, and `assets/` is no longer mistaken for a package.

## Why CI did not catch this

`python.yml` runs `pytest` from the source tree, where `main.py` is importable
whether or not it made it into the wheel. A smoke test would close the gap —
happy to add it here or in a follow-up:

```yaml
- name: Smoke test the installed console script
  run: |
    cd "$(mktemp -d)"
    gomod-go-version-updater --help || true
    python -c "import main"
```

Hardening `action.yml` to use a plain assignment plus a non-empty check on the
version output would also turn this class of failure into a red job instead of a
silent no-op. Left out of this PR to keep it focused.
